### PR TITLE
Update style props when updated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  StyleSheet,
   Animated,
   ViewPropTypes
 } from 'react-native';
@@ -51,14 +50,26 @@ function createComponent(WrappedComponent) {
       if(this.props.animateInitial) this.animate();
     }
 
-    componentWillReceiveProps(props) {
-      if(props.active != this.state.active) {
+    componentDidUpdate(previousProps) {
+      if ((previousProps.style !== this.props.style) || 
+          (previousProps.animatedStyle !== this.props.animatedStyle) || 
+          (previousProps.animateInitial !== this.props.animateInitial)
+      ){
+        this.setState({ defaultStyle: this.getDefaultStyle() })
+      }
+
+      if ((previousProps.style !== this.props.style) || (previousProps.animatedStyle !== this.props.animatedStyle) ){
+        this.setState({ animatedStyle: this.getAnimatedStyle() })
+      }
+      
+      if (this.props.active != this.state.active) {
         this.setState({
-          active: props.active
+          active: this.props.active
         }, () => {
           this.animate();
         })
       }
+
     }
 
     getDefaultStyle() {


### PR DESCRIPTION
We have dynamic handling of our stylesheet in our app. We use a custom hook to inject our theme to our stylesheet. As such, this library was not working as our style object would change in the lifetime of the component. I had to make the View update its inner state when receiving new props in order for it to work for our use case. 

I also remove `componentWillReceiveProps` in favor of `componentDidUpdate` to remove the deprecated warning.